### PR TITLE
Removes Iris Couch as it no longer exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,6 @@ Pull-Requests are welcomed.
 
 - [Cloudant](https://cloudant.com/) - Distributed database as a service (DBaaS).
 - [Smileupps](https://www.smileupps.com/) - CouchDB hosting.
-- [IrisCouch](http://www.iriscouch.com/) - Cloud CouchDB.
 - [Bitnami Launchpad for Google Cloud Platform](https://bitnami.com/stack/couchdb/cloud/google) - Host CouchDB on Google Cloud Platform.
 
 


### PR DESCRIPTION
Iris Couch does not seem to exist anymore.

Iris Couch was aquired by NodeJitsu in 2013, which in turn was aquired by GoDaddy in 2015.